### PR TITLE
Sodapop slide transitions

### DIFF
--- a/dist/neodigm55__v5_0.css
+++ b/dist/neodigm55__v5_0.css
@@ -261,6 +261,21 @@ neodigm-sodapop:not(.ndsp__modal)::after {
     neodigm-sodapop.ndsp__size--medium { width: 66%; }
     neodigm-sodapop.ndsp__size--large  { width: 88%; }
 }
+/* Slide from right drawer */
+neodigm-sodapop.ndsp__transition--slide-right {
+    transform: translateX(100%);
+    transition: transform 0.35s cubic-bezier(0, 0, 0.2, 1);
+    top: 0 !important;
+    right: 0;
+    left: auto;
+    height: 100vh;
+    max-height: 100vh;
+    border-radius: 0;
+}
+neodigm-sodapop.ndsp__transition--slide-right.ndsp__opened {
+    transform: translateX(0);
+}
+
 @media print { neodigm-sodapop-scrim-close { z-index: -256 !important;} }
 /*  Neodigm Soda Pop End  */
 
@@ -281,6 +296,11 @@ neodigm-carousel > section {
     grid-area: box-content; box-sizing: border-box; align-content: center;  
     margin: 0 auto; padding: 8px; margin-left: 1px;
 	transition: all .86s ease-in-out;
+}
+neodigm-carousel > section[data-n55-carousel-flush="true"] {
+    padding-left: 0;
+    padding-right: 0;
+    margin-left: 0;
 }
 neodigm-carousel > section > section { position: relative; display: block; }
 

--- a/dist/neodigm55__v5_0.js
+++ b/dist/neodigm55__v5_0.js
@@ -349,7 +349,7 @@ let neodigmToast = (function(_d, eID, _q) {
 class NeodigmSodaPop {
     constructor(_d, _aQ) {  //  Flux Capacitor
         this._d = _d; this._aQ = _aQ; this.sId = ""
-        this.eSoda = this.eScrim = this.eClose = this.fOnBeforeUserExit = null
+        this.eSoda = this.eScrim = this.eClose = this.fOnBeforeUserExit = null; this.sTransition = ""
         this.fOnBeforeOpen = {}; this.fOnAfterOpen = {}; this.fOnClose = {}
         this.bIsOpen = this.bIsModal = this.bIsInit = false
     }
@@ -401,7 +401,9 @@ class NeodigmSodaPop {
             setTimeout(function() { neodigmSodaPop.eScrim.classList.add("ndsp__blur"); }, 96)
             if( this.bIsModal ) this.eSoda.classList.add( "ndsp__modal" )
             this.eSoda.dataset.n55AmpmTheme = ( this.eTmpl.dataset?.n55AmpmTheme ) ? this.eTmpl.dataset.n55AmpmTheme : ""  //  Isolate Pup AMPM theme
-            this.eSoda.classList.add("ndsp__size--" + this.eTmpl.dataset.n55SodapopSize ) 
+            this.eSoda.classList.add("ndsp__size--" + this.eTmpl.dataset.n55SodapopSize )
+            this.sTransition = this.eTmpl.dataset.n55SodapopTransition || ""
+            if( this.sTransition ) this.eSoda.classList.add("ndsp__transition--" + this.sTransition)
             if( neodigmOpt.N55_SP_DISABLE_SCROLL ) neodigmSodaPop.eSoda.classList.add( "ndsp__bodyscroll" )
             setTimeout(function() { neodigmSodaPop.eSoda.classList.add("ndsp__opened"); }, 276)
             this.eSoda.innerHTML = this.eTmpl.innerHTML
@@ -435,6 +437,15 @@ class NeodigmSodaPop {
                     this.eSoda.remove()
                     this.eScrim.dataset.n55SodapopScrim = "closed"
                     this.eScrim.classList.remove("ndsp__blur", "ndsp__modal")
+                } else if( this.sTransition ) {
+                    this.eSoda.classList.remove("ndsp__opened")
+                    setTimeout(function() {
+                        neodigmSodaPop.eSoda.remove()
+                        setTimeout(function() {
+                            neodigmSodaPop.eScrim.dataset.n55SodapopScrim = "closed"
+                            neodigmSodaPop.eScrim.classList.remove("ndsp__blur", "ndsp__modal")
+                        }, 332)
+                    }, 370)
                 } else {
                     setTimeout(function() {
                         neodigmSodaPop.eSoda.remove()

--- a/dist/neodigm55__v5_0.js
+++ b/dist/neodigm55__v5_0.js
@@ -1867,6 +1867,7 @@ class NeodigmCarousel {
     elNC.n55State.aTabCntr = [ ... elNCCntr.querySelectorAll(":scope >section") ]  //  Tab Containers
     elNCCntr.style.width = ( elNC.n55State.aTabCntr.length * elNC.n55State.width ) + "px" // First Section contr width * num children
     elNCCntr.style.gridTemplateColumns = "repeat(" + elNC.n55State.aTabCntr.length + ", 1fr)"
+    if( elNCCntr.querySelector("[data-n55-carousel-flush='true']") ) elNCCntr.setAttribute("data-n55-carousel-flush", "true")
     Array.from( elNCCntr.querySelectorAll("[data-n55-cloak='true']") ).forEach( ( elCloak )=>{
       elCloak.dataset.n55Cloak = "false"
     } )


### PR DESCRIPTION
Fix: bubble data-n55-carousel-flush attribute from child page sections up to the wrapper section during carousel init so the CSS selector actually matches.